### PR TITLE
SPE-657 Heartbeat gives nullptr exception on startup, and also doesn't respect configuration

### DIFF
--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/HeartbeatScheduler.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/HeartbeatScheduler.java
@@ -4,25 +4,24 @@ import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @FieldDefaults(makeFinal = true)
 public class HeartbeatScheduler {
 
-    private static final int INITIAL_TASK_DELAY_IN_SECONDS = 1;
-    private static final int TASK_DELAY_IN_SECONDS = 1;
-
     private HeartbeatSenderTask heartbeatTask;
+    private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
     public HeartbeatScheduler(StationState stationState, StationMessageSender stationMessageSender) {
         this.heartbeatTask = new HeartbeatSenderTask(stationState, stationMessageSender);
-        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-                heartbeatTask, INITIAL_TASK_DELAY_IN_SECONDS, TASK_DELAY_IN_SECONDS, TimeUnit.SECONDS);
     }
 
     public void updateHeartbeat(int heartbeatInterval) {
         log.debug("Updating heartbeat to {} sec.", heartbeatInterval);
         heartbeatTask.updateHeartBeatInterval(heartbeatInterval);
+        scheduledExecutorService.scheduleAtFixedRate(
+                heartbeatTask, heartbeatInterval, heartbeatInterval, TimeUnit.SECONDS);
     }
 }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/HeartbeatScheduler.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/HeartbeatScheduler.java
@@ -11,6 +11,8 @@ import java.util.concurrent.TimeUnit;
 @FieldDefaults(makeFinal = true)
 public class HeartbeatScheduler {
 
+    private static final int TASK_DELAY_IN_SECONDS = 1;
+
     private HeartbeatSenderTask heartbeatTask;
     private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
@@ -22,6 +24,6 @@ public class HeartbeatScheduler {
         log.debug("Updating heartbeat to {} sec.", heartbeatInterval);
         heartbeatTask.updateHeartBeatInterval(heartbeatInterval);
         scheduledExecutorService.scheduleAtFixedRate(
-                heartbeatTask, heartbeatInterval, heartbeatInterval, TimeUnit.SECONDS);
+                heartbeatTask, TASK_DELAY_IN_SECONDS, TASK_DELAY_IN_SECONDS, TimeUnit.SECONDS);
     }
 }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/HeartbeatScheduler.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/HeartbeatScheduler.java
@@ -4,7 +4,6 @@ import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -14,16 +13,15 @@ public class HeartbeatScheduler {
     private static final int TASK_DELAY_IN_SECONDS = 1;
 
     private HeartbeatSenderTask heartbeatTask;
-    private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
     public HeartbeatScheduler(StationState stationState, StationMessageSender stationMessageSender) {
         this.heartbeatTask = new HeartbeatSenderTask(stationState, stationMessageSender);
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
+                heartbeatTask, TASK_DELAY_IN_SECONDS, TASK_DELAY_IN_SECONDS, TimeUnit.SECONDS);
     }
 
     public void updateHeartbeat(int heartbeatInterval) {
         log.debug("Updating heartbeat to {} sec.", heartbeatInterval);
         heartbeatTask.updateHeartBeatInterval(heartbeatInterval);
-        scheduledExecutorService.scheduleAtFixedRate(
-                heartbeatTask, TASK_DELAY_IN_SECONDS, TASK_DELAY_IN_SECONDS, TimeUnit.SECONDS);
     }
 }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationMessageSender.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationMessageSender.java
@@ -323,7 +323,7 @@ public class StationMessageSender {
 
     private <REQ> Call createAndRegisterCall(ActionType actionType, REQ payload) {
 
-        String callId = callIdGenerator.get();
+        String callId = callIdGenerator.generate();
 
         Call call = new Call(callId, actionType, payload);
 

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationMessageSender.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationMessageSender.java
@@ -42,6 +42,8 @@ public class StationMessageSender {
 
     private volatile LocalDateTime timeOfLastMessageSent;
 
+    private final CallIdGenerator callIdGenerator = new CallIdGenerator();
+
     public StationMessageSender(SubscriptionRegistry subscriptionRegistry, StationState stationState, WebSocketClient webSocketClient) {
         this.stationState = stationState;
         this.callRegistry = subscriptionRegistry;
@@ -321,7 +323,7 @@ public class StationMessageSender {
 
     private <REQ> Call createAndRegisterCall(ActionType actionType, REQ payload) {
 
-        String callId = CallIdGenerator.getInstance().getAndIncrement() + "";
+        String callId = callIdGenerator.get();
 
         Call call = new Call(callId, actionType, payload);
 

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/component/StationComponent.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/component/StationComponent.java
@@ -38,7 +38,7 @@ public abstract class StationComponent {
      * Validates {@link GetVariableDatum} for proper variable path (variable name, instance, attributeType, evseId, connectorId) and read access.
      * Retrieves variable from station.
      *
-     * @param getVariableDatum contains necessary data to get variable from station
+     * @param getVariableDatum contains necessary data to generate variable from station
      * @return result of getting variable
      */
     public GetVariableResult getVariable(GetVariableDatum getVariableDatum) {

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/support/CallIdGenerator.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/support/CallIdGenerator.java
@@ -3,18 +3,18 @@ package com.evbox.everon.ocpp.simulator.station.support;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Singleton that generates call id. Used in the {@link com.evbox.everon.ocpp.simulator.station.StationMessageSender}.
+ * Generates call id. Used in the {@link com.evbox.everon.ocpp.simulator.station.StationMessageSender}.
  */
 public final class CallIdGenerator {
 
     private final AtomicInteger callId = new AtomicInteger(1);
 
     /**
-     * Return current call id value and increment.
+     * Generates new call id.
      *
      * @return current call id value
      */
-    public String get() {
+    public String generate() {
         return String.valueOf(callId.getAndIncrement());
     }
 }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/support/CallIdGenerator.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/support/CallIdGenerator.java
@@ -1,40 +1,20 @@
 package com.evbox.everon.ocpp.simulator.station.support;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * Singleton that generates call id. Used in the {@link com.evbox.everon.ocpp.simulator.station.StationMessageSender}.
  */
 public final class CallIdGenerator {
 
-    /**
-     * Call id thread-local
-     */
-    private final ThreadLocal<Integer> callId = ThreadLocal.withInitial(() -> 1);
-
-    private CallIdGenerator() {
-    }
-
-    /**
-     * Lazily return an instance of {@link CallIdGenerator}.
-     *
-     * @return an instance
-     */
-    public static CallIdGenerator getInstance() {
-        return CallIdGeneratorHolder.INSTANCE;
-    }
+    private final AtomicInteger callId = new AtomicInteger(1);
 
     /**
      * Return current call id value and increment.
      *
      * @return current call id value
      */
-    public Integer getAndIncrement() {
-        Integer value = callId.get();
-        callId.set(value + 1);
-        return value;
-    }
-
-    private static final class CallIdGeneratorHolder {
-
-        private static final CallIdGenerator INSTANCE = new CallIdGenerator();
+    public String get() {
+        return String.valueOf(callId.getAndIncrement());
     }
 }

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/station/StationMessageSenderTest.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/station/StationMessageSenderTest.java
@@ -7,8 +7,6 @@ import com.evbox.everon.ocpp.simulator.station.evse.Evse;
 import com.evbox.everon.ocpp.simulator.station.evse.EvseTransaction;
 import com.evbox.everon.ocpp.simulator.station.evse.EvseTransactionStatus;
 import com.evbox.everon.ocpp.simulator.station.subscription.SubscriptionRegistry;
-import com.evbox.everon.ocpp.simulator.station.support.CallIdGenerator;
-import com.evbox.everon.ocpp.simulator.support.ReflectionUtils;
 import com.evbox.everon.ocpp.simulator.websocket.WebSocketClient;
 import com.evbox.everon.ocpp.simulator.websocket.WebSocketClientInboxMessage;
 import com.evbox.everon.ocpp.v20.message.station.*;
@@ -43,7 +41,6 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class StationMessageSenderTest {
 
-
     @Mock
     StationState stationStateMock;
     @Mock
@@ -59,9 +56,6 @@ public class StationMessageSenderTest {
     void setUp() {
         this.queue = new LinkedBlockingQueue<>();
         when(webSocketClientMock.getInbox()).thenReturn(queue);
-
-        ReflectionUtils.injectMock(CallIdGenerator.getInstance(), "callId", ThreadLocal.withInitial(() -> 1));
-
         this.stationMessageSender = new StationMessageSender(subscriptionRegistryMock, stationStateMock, webSocketClientMock);
     }
 


### PR DESCRIPTION
- Fixed issue with concurrent access to CallIdGenerator
- Not sending heartbeat until BootNotification was accepted anymore