### PR TITLE
SPE-657 Heartbeat gives nullptr exception on startup, and also doesn't respect configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Starts simulator with one station, which has single EVSE and single connector at
 ### File-based configuration
 **Configuration file sample**
 ```YAML
-heartbeatInterval: 60
 stations:
   - id: EVB-P17390866
     evse:

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/StationSimulatorRunner.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/StationSimulatorRunner.java
@@ -40,7 +40,7 @@ public class StationSimulatorRunner {
 
         simulatorConfiguration.getStations().forEach(stationConfiguration -> {
 
-            Station station = new Station(stationConfiguration, simulatorConfiguration.getHeartbeatInterval());
+            Station station = new Station(stationConfiguration);
 
             station.connectToServer(serverWebSocketUrl);
 

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/configuration/ConfigurationPrinter.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/configuration/ConfigurationPrinter.java
@@ -29,7 +29,6 @@ public class ConfigurationPrinter {
         String config = header;
         config += "\n" + "";
         config += "\n" + ("OCPP URL: " + runConfiguration.getUrl());
-        config += "\n" + ("Default heartbeat interval: " + configuration.getHeartbeatInterval());
         config += "\n" + "";
         config += "\n" + "Console-ready configuration:";
         config += "\n" + toJsonString(configuration, false).replace("\"", "'");

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/configuration/SimulatorConfiguration.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/configuration/SimulatorConfiguration.java
@@ -4,22 +4,12 @@ import lombok.Data;
 
 import java.util.List;
 
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
-
 @Data
 public class SimulatorConfiguration {
 
     private static final int DEFAULT_HEARTBEAT_INTERVAL = 60;
 
-    /**
-     * Default heartbeatInterval (in seconds) for all stations
-     */
-    private Integer heartbeatInterval;
     private List<StationConfiguration> stations;
-
-    public int getHeartbeatInterval() {
-        return defaultIfNull(heartbeatInterval, DEFAULT_HEARTBEAT_INTERVAL);
-    }
 
     @Data
     public static class StationConfiguration {

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/HeartbeatSenderTask.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/HeartbeatSenderTask.java
@@ -51,6 +51,5 @@ public final class HeartbeatSenderTask implements Runnable {
     private boolean shouldSendHeartbeat(LocalDateTime now, LocalDateTime timeOfLastMessageSent) {
         return heartBeatInterval > 0 &&
                 (timeOfLastMessageSent.plusSeconds(heartBeatInterval).isBefore(now) || timeOfLastHeartbeatSent.plusDays(1).isBefore(now));
-
     }
 }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
@@ -166,9 +166,7 @@ public class Station {
      * @param newHeartbeatInterval heartbeat interval in seconds
      */
     public void updateHeartbeat(int newHeartbeatInterval) {
-        int interval = newHeartbeatInterval;
-
-        heartbeatScheduler.updateHeartbeat(interval);
-        state.setHeartbeatInterval(interval);
+        heartbeatScheduler.updateHeartbeat(newHeartbeatInterval);
+        state.setHeartbeatInterval(newHeartbeatInterval);
     }
 }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
@@ -35,7 +35,6 @@ public class Station {
             .build();
 
     private final SimulatorConfiguration.StationConfiguration configuration;
-    private final int defaultHeartBeatIntervalSec;
 
     private final StationState state;
 
@@ -52,10 +51,9 @@ public class Station {
      * Create a station using {@link SimulatorConfiguration.StationConfiguration} and defaultHeartBeatIntervalSec.
      *
      * @param configuration station configuration
-     * @param defaultHeartBeatIntervalSec heartbeat interval in seconds
      */
-    public Station(SimulatorConfiguration.StationConfiguration configuration, int defaultHeartBeatIntervalSec) {
-        this(configuration, defaultHeartBeatIntervalSec, DEFAULT_HTTP_CLIENT);
+    public Station(SimulatorConfiguration.StationConfiguration configuration) {
+        this(configuration, DEFAULT_HTTP_CLIENT);
     }
 
     /**
@@ -64,13 +62,11 @@ public class Station {
      * {@link OkHttpClient} is used for connecting and communicating with OCPP server.
      *
      * @param configuration station configuration
-     * @param defaultHeartBeatIntervalSec heart beat interval in seconds
      * @param okHttpClient http client
      */
-    public Station(SimulatorConfiguration.StationConfiguration configuration, int defaultHeartBeatIntervalSec, OkHttpClient okHttpClient) {
+    public Station(SimulatorConfiguration.StationConfiguration configuration, OkHttpClient okHttpClient) {
 
         this.configuration = configuration;
-        this.defaultHeartBeatIntervalSec = defaultHeartBeatIntervalSec;
         this.state = new StationState(configuration);
 
         this.webSocketClient = new WebSocketClient(stationMessageInbox, configuration.getId(), new OkHttpWebSocketClient(okHttpClient));
@@ -170,7 +166,7 @@ public class Station {
      * @param newHeartbeatInterval heartbeat interval in seconds
      */
     public void updateHeartbeat(int newHeartbeatInterval) {
-        int interval = newHeartbeatInterval == 0 ? defaultHeartBeatIntervalSec : newHeartbeatInterval;
+        int interval = newHeartbeatInterval;
 
         heartbeatScheduler.updateHeartbeat(interval);
         state.setHeartbeatInterval(interval);

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/station/StationTest.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/station/StationTest.java
@@ -32,7 +32,7 @@ class StationTest {
         evse.setConnectors(DEFAULT_EVSE_CONNECTORS);
         stationConfiguration.setEvse(evse);
 
-        station = new Station(stationConfiguration, DEFAULT_HEARTBEAT_INTERVAL);
+        station = new Station(stationConfiguration);
 
         injectMock(station, "webSocketClient", webSocketClientMock);
     }


### PR DESCRIPTION
- Removed default heartbeat interval configuration. Initial design was to use default interval in case CSMS sends ZERO interval in BootNotificationResponse, although this behavior is not mentioned anywhere in the specification 