### PR TITLE
Add a gradle task to release simulator to jcenter

### DIFF
--- a/simulator-core/build.gradle
+++ b/simulator-core/build.gradle
@@ -91,7 +91,7 @@ publishing {
             artifact javadocJar
             groupId 'io.github.evbox'
             artifactId 'ocpp-station-simulator'
-            version '0.1'
+            version project.version
         }
     }
 }
@@ -110,7 +110,7 @@ bintray {
     }
 
     version {
-        name = '0.1-Alpha'
+        name = 'station-simulator'
         desc = 'OCPP 2.0 Station Simulator'
     }
 

--- a/simulator-core/build.gradle
+++ b/simulator-core/build.gradle
@@ -102,4 +102,5 @@ bintray {
         desc = 'OCPP 2.0 Station Simulator'
     }
 
+    publish = true
 }

--- a/simulator-core/build.gradle
+++ b/simulator-core/build.gradle
@@ -67,10 +67,6 @@ jar {
                 'Main-Class': 'com.evbox.everon.ocpp.simulator.SimulatorLauncher'
         )
     }
-
-    from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
-    }
 }
 
 task sourcesJar(type: Jar) {

--- a/simulator-core/build.gradle
+++ b/simulator-core/build.gradle
@@ -1,10 +1,21 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+'
+    }
+}
+
 plugins {
     id 'io.franzbecker.gradle-lombok'   version '2.0'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
 }
 
-apply plugin: 'java'
 apply plugin: 'application'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'java'
+apply plugin: 'maven-publish'
 
 mainClassName = 'com.evbox.everon.ocpp.simulator.SimulatorLauncher'
 
@@ -48,4 +59,47 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+jar {
+    manifest {
+        attributes(
+                'Main-Class': 'com.evbox.everon.ocpp.simulator.SimulatorLauncher'
+        )
+    }
+
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+}
+
+publishing {
+    publications {
+        StationSimulator(MavenPublication) {
+            from components.java
+            groupId 'io.github.evbox'
+            artifactId 'ocpp-station-simulator'
+            version '0.1'
+        }
+    }
+}
+
+bintray {
+    user = project.hasProperty('user') ? project.property('user') : null
+    key = project.hasProperty('key') ? project.property('key') : null
+    publications = ['StationSimulator']
+
+    pkg {
+        repo = 'maven'
+        name = 'station-simulator'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/evbox/station-simulator.git'
+        publicDownloadNumbers = true
+    }
+
+    version {
+        name = '0.1-Alpha'
+        desc = 'OCPP 2.0 Station Simulator'
+    }
+
 }

--- a/simulator-core/build.gradle
+++ b/simulator-core/build.gradle
@@ -73,10 +73,22 @@ jar {
     }
 }
 
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    archiveClassifier = 'sources'
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+    archiveClassifier = 'javadoc'
+}
+
 publishing {
     publications {
         StationSimulator(MavenPublication) {
             from components.java
+            artifact sourcesJar
+            artifact javadocJar
             groupId 'io.github.evbox'
             artifactId 'ocpp-station-simulator'
             version '0.1'

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
@@ -153,7 +153,7 @@ public class Station {
     }
 
     /**
-     * Returns a map of callId & Call (OCPP-MessageType)
+     * Returns a map of callId and Call (OCPP-MessageType)
      *
      * @return [callId, {@link Call}] map
      */

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/Evse.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/Evse.java
@@ -239,7 +239,6 @@ public class Evse {
      * Plug connector.
      *
      * @param connectorId connector identity
-     * @return true if succeeded otherwise false
      */
     public void plug(Integer connectorId) {
 
@@ -251,7 +250,6 @@ public class Evse {
      * Unplug connector.
      *
      * @param connectorId connector identity
-     * @return true if succeeded otherwise false
      */
     public void unplug(Integer connectorId) {
 

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketMessageInbox.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketMessageInbox.java
@@ -19,7 +19,6 @@ public class WebSocketMessageInbox {
      * Add message into inbox. If no space available throws {@link StationException}.
      *
      * @param message station messages
-     * @throws {@link StationException} if could not add message
      */
     public void offer(WebSocketClientInboxMessage message) {
         boolean success = webSocketMessageInbox.offer(message);


### PR DESCRIPTION
When you want to release a new version

`gradle -Puser=draganevbox -Pkey=<api_key> -Pversion="0.1.3" bintrayUpload `

TODO: we also need safe place to store the api key (maybe circleCI?).

Including as a dependancy (mvn)
```
<dependency>
	<groupId>io.github.evbox</groupId>
	<artifactId>ocpp-station-simulator</artifactId>
	<version>0.1.0</version>
	<type>pom</type>
</dependency>
```

Or (gradle)
`compile 'io.github.evbox:ocpp-station-simulator:0.1.0'`

JCenter link: https://jcenter.bintray.com/io/github/evbox/ocpp-station-simulator/

