### PR TITLE
SPE-835 Simulator is sometimes stuck in infinite loop

### DIFF
--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketClientConfiguration.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketClientConfiguration.java
@@ -7,14 +7,20 @@ public class WebSocketClientConfiguration {
 
     public static final WebSocketClientConfiguration DEFAULT_CONFIGURATION = WebSocketClientConfiguration.builder().build();
 
-    private static final int MAX_SEND_ATTEMPTS_DEFAULT = 3;
+    private static final int MAX_SEND_ATTEMPTS_DEFAULT = 5;
     private static final long RECONNECT_INTERVAL_MS_DEFAULT = 5_000;
+    private static final long SEND_RETRY_INTERVAL_MS = 1000L * 10;
 
     private final Integer maxSendAttempts;
+    private final Long sendRetryIntervalMs;
     private final Long reconnectIntervalMs;
 
     public int getMaxSendAttempts() {
         return maxSendAttempts == null ? MAX_SEND_ATTEMPTS_DEFAULT : maxSendAttempts;
+    }
+
+    public long getSendRetryIntervalMs() {
+        return sendRetryIntervalMs == null ? SEND_RETRY_INTERVAL_MS : sendRetryIntervalMs;
     }
 
     public long getReconnectIntervalMs() {

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketClientInboxMessage.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketClientInboxMessage.java
@@ -1,8 +1,11 @@
 package com.evbox.everon.ocpp.simulator.websocket;
 
+import lombok.ToString;
+
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@ToString
 public abstract class WebSocketClientInboxMessage {
     private static final AtomicInteger SEQUENCE = new AtomicInteger();
 

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/handlers/DisconnectMessageHandler.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/handlers/DisconnectMessageHandler.java
@@ -15,6 +15,5 @@ public class DisconnectMessageHandler implements MessageHandler<WebSocketClientI
     @Override
     public void handle(WebSocketClientInboxMessage.Disconnect message) {
         webSocketClient.getWebSocketClientAdapter().disconnect();
-        webSocketClient.setConnected(false);
     }
 }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/handlers/OcppMessageHandler.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/websocket/handlers/OcppMessageHandler.java
@@ -16,12 +16,8 @@ public class OcppMessageHandler implements MessageHandler<WebSocketClientInboxMe
 
     @Override
     public void handle(WebSocketClientInboxMessage.OcppMessage message) {
-        if (webSocketClient.isConnected()) {
-            String ocppMessage = (String) message.getData().orElseThrow(() -> new IllegalArgumentException("OCPP message is null"));
-            webSocketClient.getMessageSender().send(ocppMessage);
-            log.info("SENT: {}", ocppMessage);
-        } else {
-            webSocketClient.getInbox().offer(message);
-        }
+        String ocppMessage = (String) message.getData().orElseThrow(() -> new IllegalArgumentException("OCPP message is null"));
+        webSocketClient.getMessageSender().send(ocppMessage);
+        log.info("SENT: {}", ocppMessage);
     }
 }

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketClientTest.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketClientTest.java
@@ -11,7 +11,6 @@ import java.net.ConnectException;
 
 import static com.evbox.everon.ocpp.mock.constants.StationConstants.STATION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 
@@ -29,7 +28,7 @@ public class WebSocketClientTest {
 
     @BeforeEach
     void setUp() {
-        client = new WebSocketClient(stationMessageInboxMock, STATION_ID, webSocketClientAdapterMock, new WebSocketClientConfiguration(1, RECONNECT_INTERVAL_MS));
+        client = new WebSocketClient(stationMessageInboxMock, STATION_ID, webSocketClientAdapterMock, new WebSocketClientConfiguration(1, 0L, RECONNECT_INTERVAL_MS));
     }
 
     @Test

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketMessageSenderTest.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/websocket/WebSocketMessageSenderTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,6 +15,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 public class WebSocketMessageSenderTest {
 
+    private static final int SEND_RETRY_INTERVAL_MS = 0;
     private static int MAX_SEND_ATTEMPTS = 5;
 
     @Mock
@@ -23,20 +25,23 @@ public class WebSocketMessageSenderTest {
 
     @BeforeEach
     void setUp() {
-        mesageSender = new WebSocketMessageSender(webSocketClientAdapterMock, MAX_SEND_ATTEMPTS);
+        mesageSender = new WebSocketMessageSender(webSocketClientAdapterMock, SEND_RETRY_INTERVAL_MS, MAX_SEND_ATTEMPTS);
     }
 
     @Test
     void shouldRetrySendingMessages() {
         //given
-        given(webSocketClientAdapterMock.sendMessage(any())).willReturn(false);
+        given(webSocketClientAdapterMock.sendMessage(any()))
+                .willReturn(false)
+                .willReturn(false)
+                .willReturn(true);
 
 
         //when
         mesageSender.send("hello");
 
         //then
-        verify(webSocketClientAdapterMock, times(MAX_SEND_ATTEMPTS)).sendMessage(any());
+        verify(webSocketClientAdapterMock, times(3)).sendMessage(contains("hello"));
     }
 
 }


### PR DESCRIPTION
- Moved re-send logic closer to WebSocket client
- Added sleep time before sending retries with linear back-off
- Removed redundant 'connected' flag to track WS connection state