### PR TITLE
feature/EVS-1217-Add-configurable-Evse-connectorStatus

### DIFF
--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/configuration/SimulatorConfiguration.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/configuration/SimulatorConfiguration.java
@@ -1,6 +1,7 @@
 package com.evbox.everon.ocpp.simulator.configuration;
 
 import com.evbox.everon.ocpp.simulator.station.component.transactionctrlr.TxStartStopPointVariableValues;
+import com.evbox.everon.ocpp.v20.message.station.StatusNotificationRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,6 +29,8 @@ public class SimulatorConfiguration {
 
     private static final long DEFAULT_PING_INTERVAL = 30_000;
 
+    private static final StatusNotificationRequest.ConnectorStatus DEFAULT_EVSE_CONNECTOR_STATUS = StatusNotificationRequest.ConnectorStatus.AVAILABLE;
+
     private WebSocketConfiguration socketConfiguration;
     private List<StationConfiguration> stations;
 
@@ -50,6 +53,11 @@ public class SimulatorConfiguration {
          * Amount of connectors per each EVSE
          */
         private int connectors;
+
+        /**
+         * Status of connector per each EVSE
+         */
+        private StatusNotificationRequest.ConnectorStatus connectorStatus = DEFAULT_EVSE_CONNECTOR_STATUS;
     }
 
     @Data

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
@@ -151,7 +151,7 @@ public class Station {
 
                 for (int i = 1; i <= configuration.getEvse().getCount(); i++) {
                     for (int j = 1; j <= configuration.getEvse().getConnectors(); j++) {
-                        stationMessageSender.sendStatusNotification(i, j);
+                        stationMessageSender.sendStatusNotification(i, j, configuration.getEvse().getConnectorStatus());
                     }
                 }
             }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationStore.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationStore.java
@@ -10,6 +10,7 @@ import com.evbox.everon.ocpp.simulator.station.evse.Evse.EvseView;
 import com.evbox.everon.ocpp.simulator.station.exceptions.StationException;
 import com.evbox.everon.ocpp.v20.message.station.ConnectionData;
 import com.evbox.everon.ocpp.v20.message.station.Reservation;
+import com.evbox.everon.ocpp.v20.message.station.StatusNotificationRequest;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -60,7 +61,7 @@ public class StationStore {
 
     public StationStore(SimulatorConfiguration.StationConfiguration configuration) {
         this.stationId = configuration.getId();
-        this.evses = initEvses(configuration.getEvse().getCount(), configuration.getEvse().getConnectors());
+        this.evses = initEvses(configuration.getEvse().getCount(), configuration.getEvse().getConnectors(), configuration.getEvse().getConnectorStatus());
         this.evConnectionTimeOut = configuration.getComponentsConfiguration().getTxCtrlr().getEvConnectionTimeOutSec();
         this.txStartPointValues = new OptionList<>(TxStartStopPointVariableValues.fromValues(configuration.getComponentsConfiguration().getTxCtrlr().getTxStartPoints()));
         this.txStopPointValues = new OptionList<>(TxStartStopPointVariableValues.fromValues(configuration.getComponentsConfiguration().getTxCtrlr().getTxStopPoints()));
@@ -279,14 +280,14 @@ public class StationStore {
         return this.networkConfigurationPriority;
     }
 
-    private Map<Integer, Evse> initEvses(Integer evseCount, Integer connectorsPerEvseCount) {
+    private Map<Integer, Evse> initEvses(Integer evseCount, Integer connectorsPerEvseCount, StatusNotificationRequest.ConnectorStatus connectorStatus) {
 
         ImmutableMap.Builder<Integer, Evse> evseMapBuilder = ImmutableMap.builder();
 
         for (int evseId = 1; evseId <= evseCount; evseId++) {
             ImmutableList.Builder<Connector> connectorListBuilder = ImmutableList.builder();
             for (int connectorId = 1; connectorId <= connectorsPerEvseCount; connectorId++) {
-                connectorListBuilder.add(new Connector(connectorId, CableStatus.UNPLUGGED, AVAILABLE));
+                connectorListBuilder.add(new Connector(connectorId, CableStatus.UNPLUGGED, connectorStatus));
             }
 
             evseMapBuilder.put(evseId, new Evse(evseId, connectorListBuilder.build()));


### PR DESCRIPTION
Add a connectorStatus property to SimulatorConfiguration so that the stations can be started with a specific status rather than defaulting to `AVAILABLE` when the simulator starts