### PR TITLE
Upgrade Gradle plugins and dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.jsonschema2pojo:jsonschema2pojo-gradle-plugin:1.0.0'
+        classpath 'org.jsonschema2pojo:jsonschema2pojo-gradle-plugin:1.1.1'
     }
 }
 

--- a/simulator-core/build.gradle
+++ b/simulator-core/build.gradle
@@ -28,10 +28,6 @@ run {
     standardInput = System.in
 }
 
-lombok {
-    version = "1.18.4"
-    sha256 = "39f3922deb679b1852af519eb227157ef2dd0a21eec3542c8ce1b45f2df39742"
-}
 
 dependencies {
 
@@ -53,6 +49,12 @@ dependencies {
     api "com.google.guava:guava:${guavaVersion}"
 
     api group: 'commons-codec', name: 'commons-codec', version: '1.12'
+    
+    // Lombok
+	compileOnly 'org.projectlombok:lombok:1.18.24'
+	annotationProcessor 'org.projectlombok:lombok:1.18.24'	
+	testCompileOnly 'org.projectlombok:lombok:1.18.24'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
 
     testImplementation 'org.assertj:assertj-core:3.13.0'
     testImplementation 'io.undertow:undertow-core:2.0.17.Final'
@@ -77,7 +79,7 @@ jacocoTestReport {
 }
 
 jacoco {
-    toolVersion = '0.8.5'
+    toolVersion = '0.8.8'
 }
 tasks['test'].finalizedBy 'jacocoTestReport'
 


### PR DESCRIPTION
WIth this configuration of Gradle and Java:

    gradle --version

    ------------------------------------------------------------
    Gradle 7.4
    ------------------------------------------------------------
    
    Build time:   2022-02-08 09:58:38 UTC
    Revision:     f0d9291c04b90b59445041eaa75b2ee744162586
    
    Kotlin:       1.5.31
    Groovy:       3.0.9
    Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
    JVM:          17.0.2 (Private Build 17.0.2+8-Ubuntu-118.04)
    OS:           Linux 5.4.0-109-generic amd64

The build encounters multiple failures. We managed to make the build pass with the following updates:

- lombok
- jacoco
- jsonschema2pojo-gradle-plugin